### PR TITLE
Modify README.md and launch files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 DynPick ROS driver
 ==================================
 
+![WDF-6M200-3](http://www.wacoh-tech.com/img/img_model_wdf_6m200_3.jpg "WDF-6M200-3")
+
 ROS driver for [Wacoh-tech force sensor](http://www.wacoh-tech.com/en/products/dynpick/).
 
 Prerequisite
@@ -63,6 +65,7 @@ You can view the force and torque vectors in rviz by launching sample.launch:
  * `rate`: refresh rate
  * `sensor_frame_id`: This name will be used as a [tf](http://wiki.ros.org/tf) frame of the connected sensor device
  * `rvizconfig`: name of the [RViz configuration file](http://wiki.ros.org/rviz/UserGuide#Configurations) that can be used for storing your own `RViz` setting
+ * `topic`: name of the published topic (WrenchStamped). Default is '/force'
 
 Video is posted on ROS wiki (http://wiki.ros.org/action/subscribe/dynpick_driver)
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ $ catkin_make
 Operation
 ==========
 
+You can view the force and torque vectors in rviz by launching sample.launch:
+
 ```
- $ roslaunch dynpick_driver run.launch
+ $ roslaunch dynpick_driver sample.launch
 ```
 
  You can configure some things by passing arguments:
+
  ```
- $ roslaunch dynpick_driver run.launch device:=/dev/ttyUSB0 rate:=50 sensor_frame_id:=/sensor/force rvizconfig:=`rospack find dynpick_driver`/launch/sample.rviz
+ $ roslaunch dynpick_driver sample.launch device:=/dev/ttyUSB0 rate:=500 sensor_frame_id:=/sensor rvizconfig:=`rospack find dynpick_driver`/launch/sample.rviz
 ```
 
  where:

--- a/launch/run.launch
+++ b/launch/run.launch
@@ -2,13 +2,11 @@
   <arg name="device" default="/dev/ttyUSB0" />
   <arg name="rate" default="1000" />
   <arg name="sensor_frame_id" default="/sensor" />
-  <arg name="rvizconfig" default="$(find dynpick_driver)/launch/sample.rviz" />
+  <arg name="topic" default="/force" />
   <node pkg="dynpick_driver" name="dynpick_driver_node" type="dynpick_driver_node" >
     <param name="device" value="$(arg device)" />
-    <param name="rate"   value="$(arg rate)" />
-    <param name="frame_id"  value="$(arg sensor_frame_id)" />
+    <param name="rate" value="$(arg rate)" />
+    <param name="frame_id" value="$(arg sensor_frame_id)" />
+    <remap from="/force" to="$(arg topic)" />
   </node>
-
-  <node pkg="rviz" type="rviz" name="rviz"
-        args="-d $(arg rvizconfig)" />
 </launch>

--- a/launch/sample.launch
+++ b/launch/sample.launch
@@ -7,8 +7,8 @@
     <arg name="device" value="$(arg device)" />
     <arg name="rate" value="$(arg rate)" />
     <arg name="sensor_frame_id" value="$(arg sensor_frame_id)" />
-    <arg name="rvizconfig" value="$(arg rvizconfig)" />
   </include>
   <node pkg="tf" type="static_transform_publisher" name="base_to_sensor"
         args="0 0 0.5 0 0 0 /base /sensor 100" />
+  <node pkg="rviz" type="rviz" name="rviz" args="-d $(arg rvizconfig)" />
 </launch>


### PR DESCRIPTION
* The release version(0.0.3) has no run.launch, so I guess we should use sample.launch for quick start.
* Add product photo link.
* The launch file is modified. Now run.launch for only publishing sensor data, and sample.launch is for quick start and visualization.
