### PR TITLE
Workaround for ROS buildfarm error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,6 @@ include_directories(
 add_executable(dynpick_driver_node src/main.cpp src/kbhit.c)
 target_link_libraries(dynpick_driver_node ${catkin_LIBRARIES})
 
-add_executable(dynpick_com_tester src/test-com.c)
-
 #############
 ## Install ##
 #############
@@ -53,7 +51,7 @@ add_executable(dynpick_com_tester src/test-com.c)
 # )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS dynpick_driver_node dynpick_com_tester
+install(TARGETS dynpick_driver_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/src/test-com.c
+++ b/src/test-com.c
@@ -1,4 +1,9 @@
 // test-com.c
+
+/*
+ * Build with `gcc -o`. See https://github.com/start-jsk/rtmros_hironx/blob/6eb507f3ad0ed368d909960dd59ddaac0f77f496/hironx_ros_bridge/robot/dynpick/Makefile#L9
+ */
+
 #define 	DEBUGSS	0
 
 #include	<stdio.h>


### PR DESCRIPTION
Reported [in-code](https://github.com/tork-a/dynpick_driver/pull/25/files/8208f2b6391c55291416be2ff2c252ac7b3693df#r65633103) at #25.

Implementing solution might be possible ([example](http://stackoverflow.com/questions/17260409/fprintf-error-format-not-a-string-literal-and-no-format-arguments-werror-for)) but considering the effort it takes, having it built on ROS buildfarm is less beneficial. I rather mit it to be built.  