### PR TITLE
Revert "Workaround for ROS buildfarm error."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 add_executable(dynpick_driver_node src/main.cpp src/kbhit.c)
 target_link_libraries(dynpick_driver_node ${catkin_LIBRARIES})
 
+add_executable(dynpick_com_tester src/test-com.c)
+
 #############
 ## Install ##
 #############
@@ -53,7 +55,7 @@ target_link_libraries(dynpick_driver_node ${catkin_LIBRARIES})
 # )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS dynpick_driver_node
+install(TARGETS dynpick_driver_node dynpick_com_tester
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/src/test-com.c
+++ b/src/test-com.c
@@ -1,9 +1,4 @@
 // test-com.c
-
-/*
- * Build with `gcc -o`. See https://github.com/start-jsk/rtmros_hironx/blob/6eb507f3ad0ed368d909960dd59ddaac0f77f496/hironx_ros_bridge/robot/dynpick/Makefile#L9
- */
-
 #define 	DEBUGSS	0
 
 #include	<stdio.h>


### PR DESCRIPTION
Reverts tork-a/dynpick_driver#27