### PR TITLE
Confirmed operation with Melodic.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>dynpick_driver</name>
   <version>0.2.0</version>
   <description>Driver package for Wacohtech dynpick force sensor. This contains <a href = "http://ros.org/">ROS</a>-compatible linux driver, as well as a communication test tool.<br />
@@ -28,13 +28,13 @@
   <build_depend>python-catkin-pkg</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_srvs</build_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>std_srvs</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>xacro</run_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <test_depend>rostest</test_depend>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
 
     // Set frequncy divider filter
     if (frq_div == 1 || frq_div == 2 || frq_div == 4 || frq_div == 8) {
-        char cmd[2];
+        char cmd[3];
         sprintf(cmd, "%dF", frq_div);
         write(fdc, cmd, 2);
         ROS_INFO("Set the frequency divider to %s", cmd);


### PR DESCRIPTION
## Change
- fixed buffer overflow
Buffer overflow was caused by missing buffer size in *cmd* at line 174 of src/main.cpp.
- moved the package.xml to format 2 to match the melodic version．