### PR TITLE
mod launch options and add "Troubleshooting" section in doc/index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -97,9 +97,24 @@ Parameters
   Publish rate. Default: 1000 hz
 
 Documentation
---------
+---------------
 
 `API doc is available <http://docs.ros.org/indigo/api/dynpick_driver/html/>`_ also on `ros.org.<http://wiki.ros.org/dynpick_driver>`_
+
+Troubleshooting
+=====================
+
+1. ``/force`` topic exists but does not publish any data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There is a possibility that the conditions are such that serial communication error occurs.
+
+Please try launch options of ``frequency_div:=-1`` and ``acquire_calibration:=false`` 
+for sample.launch or driver.launch as follows.
+
+``$ roslaunch dynpick_driver driver.launch frequency_div:=-1 acquire_calibration:=false``
+
+``$ roslaunch dynpick_driver sample.launch frequency_div:=-1 acquire_calibration:=false``
 
 DEB build status
 ================

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -4,13 +4,14 @@
   <arg name="sensor_frame_id" default="/sensor" />
   <arg name="topic" default="/force" />
   <arg name="frequency_div" default="1" />
+  <arg name="acquire_calibration" value="true"/>
 
   <node pkg="dynpick_driver" name="dynpick_driver_node" type="dynpick_driver_node" >
     <param name="device" value="$(arg device)" />
     <param name="rate" value="$(arg rate)" />
     <param name="frame_id" value="$(arg sensor_frame_id)" />
     <param name="frequency_div" value="$(arg frequency_div)" />
+    <param name="acquire_calibration" value="$(arg acquire_calibration)"/>
     <remap from="/force" to="$(arg topic)" />
-    <param name="acquire_calibration" value="true"/>
   </node>
 </launch>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -4,7 +4,7 @@
   <arg name="sensor_frame_id" default="/sensor" />
   <arg name="topic" default="/force" />
   <arg name="frequency_div" default="1" />
-  <arg name="acquire_calibration" value="true"/>
+  <arg name="acquire_calibration" default="true"/>
 
   <node pkg="dynpick_driver" name="dynpick_driver_node" type="dynpick_driver_node" >
     <param name="device" value="$(arg device)" />

--- a/launch/sample.launch
+++ b/launch/sample.launch
@@ -5,12 +5,16 @@
   <arg name="run_rviz" default="true" />
   <arg name="rvizconfig" default="$(find dynpick_driver)/launch/sample.rviz" />
   <arg name="topic" default="/force" />
+  <arg name="frequency_div" default="1" />
+  <arg name="acquire_calibration" value="true"/>
 
   <include file="$(find dynpick_driver)/launch/driver.launch">
     <arg name="device" value="$(arg device)" />
     <arg name="rate" value="$(arg rate)" />
     <arg name="sensor_frame_id" value="$(arg sensor_frame_id)" />
     <arg name="topic" value="$(arg topic)" />
+    <arg name="frequency_div" value="$(arg frequency_div)" />
+    <arg name="acquire_calibration" value="$(arg acquire_calibration)"/>
   </include>
 
   <node pkg="rviz" type="rviz" name="rviz" args="-d $(arg rvizconfig)"

--- a/launch/sample.launch
+++ b/launch/sample.launch
@@ -6,7 +6,7 @@
   <arg name="rvizconfig" default="$(find dynpick_driver)/launch/sample.rviz" />
   <arg name="topic" default="/force" />
   <arg name="frequency_div" default="1" />
-  <arg name="acquire_calibration" value="true"/>
+  <arg name="acquire_calibration" default="true"/>
 
   <include file="$(find dynpick_driver)/launch/driver.launch">
     <arg name="device" value="$(arg device)" />


### PR DESCRIPTION
mod launch options for a /force topic publishing error with serial communication errors and add Troubleshooting section in document doc/index.rst.

The issue is https://github.com/tork-a/dynpick_driver/issues/48.